### PR TITLE
Build system improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILD_FOLDER  = $(shell pwd)/build
+BUILD_FOLDER  = $(CURDIR)/build
 
 FLAGS_LINUX   = GOOS=linux GOARCH=amd64 CGO_ENABLED=1
 FLAGS_DARWIN  = GOOS=darwin GOARCH=amd64 CGO_ENABLED=1

--- a/Makefile
+++ b/Makefile
@@ -4,20 +4,28 @@ FLAGS_LINUX   = GOOS=linux GOARCH=amd64 CGO_ENABLED=1
 FLAGS_DARWIN  = GOOS=darwin GOARCH=amd64 CGO_ENABLED=1
 FLAGS_FREEBSD = GOOS=freebsd GOARCH=amd64 CGO_ENABLED=1
 FLAGS_WINDOWS_386 = GOOS=windows GOARCH=386 CC=i686-w64-mingw32-gcc CGO_ENABLED=1
+FLAGS_WINDOWS_AMD64 = GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CGO_ENABLED=1
 
+KRAKEN_SRC   = $(wildcard *.go)
+LAUNCHER_SRC = $(wildcard launcher/*.go)
+COMPILER_SRC = $(wildcard compiler/*.go)
 
+.PHONY: all
+all: $(shell go env GOOS)
+
+.PHONY: lint
 lint:
 	@echo "[lint] Running linter on codebase"
 	@golint ./...
 
-
+.PHONY: deps
 deps:
 	@echo "[deps] Installing dependencies..."
 	go mod download
 	go get github.com/akavel/rsrc
 	@echo "[deps] Dependencies installed."
 
-
+.PHONY: check-env
 check-env:
 	@mkdir -p $(BUILD_FOLDER)
 
@@ -30,77 +38,120 @@ ifndef BACKEND
 endif
 
 
-rules-compiler:
+.PHONY: rules-compiler
+rules-compiler: $(BUILD_FOLDER)/compiler
+$(BUILD_FOLDER)/compiler: $(COMPILER_SRC)
 ifdef RULES
+	@mkdir -p $(@D)
+
 	@echo "[rules-compiler] Building rules compiler..."
-	@cd compiler; go build -o $(BUILD_FOLDER)/compiler; cd ..
+	@cd compiler; go build -o $@
 
 	@echo "[rules-compiler] Compiling Yara rules..."
-	@$(BUILD_FOLDER)/compiler $(RULES)
+	@$@ $(RULES)
 
 	@echo "[rules-compiler] Launching binary resource builder..."
 	@go-bindata rules
 endif
 
 
-linux: check-env rules-compiler
-	@mkdir -p $(BUILD_FOLDER)/linux
+.PHONY: linux
+linux: $(BUILD_FOLDER)/linux/kraken $(BUILD_FOLDER)/linux/kraken-launcher
 
+$(BUILD_FOLDER)/linux/kraken: $(BUILD_FOLDER)/compiler $(KRAKEN_SRC)
+	@mkdir -p $(@D)
 	@echo "[builder] Building Linux executable..."
 	@$(FLAGS_LINUX) go build --ldflags '-s -w -extldflags "-lm -static" -X main.DefaultBaseDomain=$(BACKEND)' \
-		-tags yara_static -o $(BUILD_FOLDER)/linux/kraken
-
-	# @echo "[builder] Building launcher..."
-	# @cd launcher; $(FLAGS_LINUX) go build --ldflags '-s -w' \
-	# 	-o $(BUILD_FOLDER)/linux/kraken-launcher; cd ..
-
+		-tags yara_static -o $@
 	@echo "[builder] Done!"
 
+$(BUILD_FOLDER)/linux/kraken-launcher: $(LAUNCHER_SRC)
+	@mkdir -p $(@D)
+	@echo "[builder] Building Linux launcher..."
+	@cd launcher; $(FLAGS_LINUX) go build --ldflags '-s -w' \
+		-o $@
+	@echo "[builder] Done!"
 
-darwin: check-env rules-compiler
-	@mkdir -p $(BUILD_FOLDER)/darwin
+.PHONY: darwin
+darwin: $(BUILD_FOLDER)/darwin/kraken $(BUILD_FOLDER)/darwin/kraken-launcher
 
+$(BUILD_FOLDER)/darwin/kraken: $(BUILD_FOLDER)/compiler $(KRAKEN_SRC)
+	@mkdir -p $(@D)
 	@echo "[builder] Building Darwin executable..."
 	@$(FLAGS_DARWIN) go build --ldflags '-s -w -extldflags "-lm" -X main.DefaultBaseDomain=$(BACKEND)' \
-		-tags yara_static -o $(BUILD_FOLDER)/darwin/kraken
-
-	# @echo "[builder] Building launcher..."
-	# @cd launcher; $(FLAGS_DARWIN) go build --ldflags '-s -w' \
-	# 	-o $(BUILD_FOLDER)/darwin/kraken-launcher; cd ..
-
+		-tags yara_static -o $@
 	@echo "[builder] Done!"
 
+$(BUILD_FOLDER)/darwin/kraken-launcher: $(LAUNCHER_SRC)
+	@mkdir -p $(@D)
+	@echo "[builder] Building Darwin launcher..."
+	@cd launcher; $(FLAGS_DARWIN) go build --ldflags '-s -w' \
+		-o $@
+	@echo "[builder] Done!"
 
-freebsd: check-env rules-compiler
-	@mkdir -p $(BUILD_FOLDER)/freebsd
+.PHONY: freebsd
+freebsd: $(BUILD_FOLDER)/freebsd/kraken $(BUILD_FOLDER)/freebsd/kraken-launcher
 
+$(BUILD_FOLDER)/freebsd/kraken: $(BUILD_FOLDER)/compiler $(KRAKEN_SRC)
+	@mkdir -p $(@D)
 	@echo "[builder] Building FreeBSD executable..."
 	@$(FLAGS_FREEBSD) go build --ldflags '-s -w -extldflags "-lm -static" -X main.DefaultBaseDomain=$(BACKEND)' \
-		-tags yara_static -o $(BUILD_FOLDER)/freebsd/kraken
-
-	# @echo "[builder] Building launcher..."
-	# @cd launcher; $(FLAGS_FREEBSD) go build --ldflags '-s -w' -o $(BUILD_FOLDER)/freebsd/kraken-launcher; cd ..
-
+		-tags yara_static -o $@
 	@echo "[builder] Done!"
 
+$(BUILD_FOLDER)/freebsd/kraken-launcher: $(LAUNCHER_SRC)
+	@mkdir -p $(@D)
+	@echo "[builder] Building FreeBSD launcher..."
+	@cd launcher; $(FLAGS_FREEBSD) go build --ldflags '-s -w' }
+		-o $@
+	@echo "[builder] Done!"
 
-windows-386: check-env rules-compiler
-	@mkdir -p $(BUILD_FOLDER)/windows-386
+.PHONY: windows
+windows: windows-386 windows-amd64
+
+.PHONY: windows-386
+windows-386: $(BUILD_FOLDER)/windows-386/kraken.exe $(BUILD_FOLDER)/windows-386/kraken-launcher.exe
+
+$(BUILD_FOLDER)/windows-386/kraken.exe: $(BUILD_FOLDER)/compiler $(YARA_SRC)-windows-386/done $(KRAKEN_SRC)
+	@mkdir -p $(@D)
 
 	#@rsrc -manifest kraken.manifest -ico kraken.ico -o rsrc.syso
-	@rsrc -manifest kraken.manifest -o rsrc.syso
+	@rsrc -arch 386 -manifest kraken.manifest -o rsrc_windows_386.syso
 
-	@echo "[builder] Building Windows executable..."
+	@echo "[builder] Building Windows 32bit executable..."
 	@$(FLAGS_WINDOWS_386) go build --ldflags '-s -w -extldflags "-static" -X main.DefaultBaseDomain=$(BACKEND)' \
-		-tags yara_static -o $(BUILD_FOLDER)/windows-386/kraken.exe
-
-	# @echo "[builder] Building launcher..."
-	# @cd launcher; $(FLAGS_WINDOWS) go build --ldflags '-s -w -extldflags "-static" -H=windowsgui' \
-	# 	-o $(BUILD_FOLDER)/windows/kraken-launcher.exe; cd ..
-
+		-tags yara_static -o $@
 	@echo "[builder] Done!"
 
+$(BUILD_FOLDER)/windows-386/kraken-launcher.exe: $(LAUNCHER_SRC)
+	@mkdir -p $(@D)
+	@echo "[builder] Building Windows 32bit launcher..."
+	@cd launcher; $(FLAGS_WINDOWS_386) go build --ldflags '-s -w -extldflags "-static" -H=windowsgui' \
+		-o $@
+	@echo "[builder] Done!"
 
+.PHONY: windows-amd64
+windows-amd64: $(BUILD_FOLDER)/windows-amd64/kraken.exe $(BUILD_FOLDER)/windows-amd64/kraken-launcher.exe
+
+$(BUILD_FOLDER)/windows-amd64/kraken.exe: $(BUILD_FOLDER)/compiler $(YARA_SRC)-windows-amd64/done $(KRAKEN_SRC)
+	@mkdir -p $(@D)
+
+	#@rsrc -manifest kraken.manifest -ico kraken.ico -o rsrc.syso
+	@rsrc -arch amd64 -manifest kraken.manifest -o rsrc_windows_amd64.syso
+
+	@echo "[builder] Building Windows 64bit executable..."
+	@$(FLAGS_WINDOWS_AMD64) go build --ldflags '-s -w -extldflags "-static" -X main.DefaultBaseDomain=$(BACKEND)' \
+		-tags yara_static -o $@
+	@echo "[builder] Done!"
+
+$(BUILD_FOLDER)/windows-amd64/kraken-launcher.exe: $(LAUNCHER_SRC)
+	@mkdir -p $(@D)
+	@echo "[builder] Building Windows 64bit launcher..."
+	@cd launcher; $(FLAGS_WINDOWS_AMD64) go build --ldflags '-s -w -extldflags "-static" -H=windowsgui' \
+		-o $@
+	@echo "[builder] Done!"
+
+.PHONY: clean
 clean:
 	rm -f rules
 	rm -f bindata.go

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BUILD_FOLDER  = $(CURDIR)/build
 FLAGS_LINUX   = GOOS=linux GOARCH=amd64 CGO_ENABLED=1
 FLAGS_DARWIN  = GOOS=darwin GOARCH=amd64 CGO_ENABLED=1
 FLAGS_FREEBSD = GOOS=freebsd GOARCH=amd64 CGO_ENABLED=1
-FLAGS_WINDOWS = GOOS=windows GOARCH=386 CC=i686-w64-mingw32-gcc CGO_ENABLED=1
+FLAGS_WINDOWS_386 = GOOS=windows GOARCH=386 CC=i686-w64-mingw32-gcc CGO_ENABLED=1
 
 
 lint:
@@ -84,15 +84,15 @@ freebsd: check-env rules-compiler
 	@echo "[builder] Done!"
 
 
-windows: check-env rules-compiler
-	@mkdir -p $(BUILD_FOLDER)/windows
+windows-386: check-env rules-compiler
+	@mkdir -p $(BUILD_FOLDER)/windows-386
 
 	#@rsrc -manifest kraken.manifest -ico kraken.ico -o rsrc.syso
 	@rsrc -manifest kraken.manifest -o rsrc.syso
 
 	@echo "[builder] Building Windows executable..."
-	@$(FLAGS_WINDOWS) go build --ldflags '-s -w -extldflags "-static" -X main.DefaultBaseDomain=$(BACKEND)' \
-		-tags yara_static -o $(BUILD_FOLDER)/windows/kraken.exe
+	@$(FLAGS_WINDOWS_386) go build --ldflags '-s -w -extldflags "-static" -X main.DefaultBaseDomain=$(BACKEND)' \
+		-tags yara_static -o $(BUILD_FOLDER)/windows-386/kraken.exe
 
 	# @echo "[builder] Building launcher..."
 	# @cd launcher; $(FLAGS_WINDOWS) go build --ldflags '-s -w -extldflags "-static" -H=windowsgui' \


### PR DESCRIPTION
So, here's the follow-up to my promise from #3.

I have make some changes to the Makefile that make the build a bit more robust, add a 64bit Windows target, and add cross-building YARA for Windows. This is still a lot simpler than the `3rdparty.mk` from [Spyre](https://github.com/spyre-project/spyre) but I have changed quite a lot, so I feel that a high-level explanation might be useful:

- All the main targets are now based on files generated during the build stage and they depend on the source files. This utilizes Make's main features -- inferring what needs to be (re)built from source and binary file timestamps.
- the original targets are kept around as "phony" targets that are not tied to files. For example, `windows-386` depends on `kraken.exe` and `kraken-launcher.exe` in the `build/windows-386` subdirectory. Once these two files exist and there haven't been edits to the source files since, the `windows-386` target is considered as built and re-running `make windows-386` causes a message "Nothing to be done for 'windows-386'".

It would probably make sense to also do private builds of the static YARA library for non-Windows architectures.
